### PR TITLE
Use feof() for Stream

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -128,7 +128,7 @@ class Stream implements StreamInterface
      */
     public function eof()
     {
-        return $this->isClosed() || $this->tell() == $this->getSize();
+        return $this->isClosed() || feof($this->handle);
     }
 
     /**

--- a/tests/OutputBufferStreamTest.php
+++ b/tests/OutputBufferStreamTest.php
@@ -174,10 +174,16 @@ class OutputBufferStreamTest extends PHPUnit_Framework_TestCase
     {
         $stream = $this->getStream('php://temp');
         
-        $this->assertTrue($stream->eof());
+        $this->assertFalse($stream->eof());
         
+        $stream->read(1);
+        $this->assertTrue($stream->eof());
+
         $stream->write('Foo-Baz');
         $this->assertTrue($stream->eof());
+        
+        $stream->seek(2);
+        $this->assertFalse($stream->eof());
     }
 
     public function testLocalRead()

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -206,6 +206,9 @@ class StreamTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($stream->eof());
         
         $stream->read(100);
+        $this->assertFalse($stream->eof());
+        
+        $stream->read(1);
         $this->assertTrue($stream->eof());
     }
 


### PR DESCRIPTION
Follow normal `feof()` behavior. Use `tell()` doesn't work correct for all streams.