### PR TITLE
Adhere to interface naming convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The library implements the following PSR-7 interfaces
 
 it defines one interface
 
- * [`DerivedAttribute`](#derivedattribute)
+ * [`DerivedAttributeInterface`](#derivedattribute)
 
 ### ServerRequest
 
@@ -174,14 +174,14 @@ $request = (new ServerRequest())->withAttribute('accept_json', function(ServerRe
 });
 ```
 
-You can create more sophisticated derived attributes by creating a class that implements the `DerivedAttribute`
+You can create more sophisticated derived attributes by creating a class that implements the `DerivedAttributeInterface`
 interface. When implementing that interface, implement `__invoke(ServerRequest $request)`. 
 
 ```php
 use Jasny\HttpMessage\ServerRequest;
-use Jasny\HttpMessage\DerivedAttribute;
+use Jasny\HttpMessage\DerivedAttributeInterface;
 
-class DetectBot implements DerivedAttribute
+class DetectBot implements DerivedAttributeInterface
 {
     public static $identifiers = [
         'google' => 'googlebot',

--- a/src/DerivedAttribute.php
+++ b/src/DerivedAttribute.php
@@ -2,22 +2,13 @@
 
 namespace Jasny\HttpMessage;
 
-use Psr\Http\Message\ServerRequestInterface;
-
 /**
- * A derived attribute calculates it's value based on any request parameters.
+ * For backwards compatiblity
  * 
- * DirivedAttribute objects are considered immutable; all methods that might change state MUST be implemented such that
- * they retain the internal state of the current message and return an instance that contains the changed state.
+ * @ignore
+ * @deprecated since v1.1.1
  */
-interface DerivedAttribute
+interface DerivedAttribute extends DerivedAttributeInterface
 {
-    /**
-     * Calculate the derived attribute
-     * 
-     * @param ServerRequestInterface $request
-     * @return mixed
-     */
-    public function __invoke(ServerRequestInterface $request);
 }
 

--- a/src/DerivedAttribute/ClientIp.php
+++ b/src/DerivedAttribute/ClientIp.php
@@ -2,13 +2,13 @@
 
 namespace Jasny\HttpMessage\DerivedAttribute;
 
-use Jasny\HttpMessage\DerivedAttribute;
+use Jasny\HttpMessage\DerivedAttributeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Determine the client ip, taking proxy settings into consideration
  */
-class ClientIp implements DerivedAttribute
+class ClientIp implements DerivedAttributeInterface
 {
     /**
      * CIDR address of trusted proxy

--- a/src/DerivedAttribute/IsXhr.php
+++ b/src/DerivedAttribute/IsXhr.php
@@ -2,13 +2,13 @@
 
 namespace Jasny\HttpMessage\DerivedAttribute;
 
-use Jasny\HttpMessage\DerivedAttribute;
+use Jasny\HttpMessage\DerivedAttributeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Check if request is an XHR (AJAX) request.
  */
-class IsXhr implements DerivedAttribute
+class IsXhr implements DerivedAttributeInterface
 {
     /**
      * Calculate the derived attribute.

--- a/src/DerivedAttributeInterface.php
+++ b/src/DerivedAttributeInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jasny\HttpMessage;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * A derived attribute calculates it's value based on any request parameters.
+ * 
+ * DirivedAttribute objects are considered immutable; all methods that might change state MUST be implemented such that
+ * they retain the internal state of the current message and return an instance that contains the changed state.
+ */
+interface DerivedAttributeInterface
+{
+    /**
+     * Calculate the derived attribute
+     * 
+     * @param ServerRequestInterface $request
+     * @return mixed
+     */
+    public function __invoke(ServerRequestInterface $request);
+}
+

--- a/src/ServerRequest/Attributes.php
+++ b/src/ServerRequest/Attributes.php
@@ -3,6 +3,7 @@
 namespace Jasny\HttpMessage\ServerRequest;
 
 use Jasny\HttpMessage\DerivedAttribute;
+use Jasny\HttpMessage\DerivedAttributeInterface;
 
 /**
  * ServerRequest attributes methods
@@ -43,7 +44,7 @@ trait Attributes
         $attributes = [];
         
         foreach ($this->attributes as $name => $attr) {
-            $value = $attr instanceof \Closure || $attr instanceof DerivedAttribute ? $attr($this) : $attr;
+            $value = $attr instanceof \Closure || $attr instanceof DerivedAttributeInterface ? $attr($this) : $attr;
             $attributes[$name] = $value;
         }
         
@@ -69,7 +70,7 @@ trait Attributes
         $key = \Jasny\snakecase($name);
         
         $attr = isset($this->attributes[$key]) ? $this->attributes[$key] : null;
-        $value = $attr instanceof \Closure || $attr instanceof DerivedAttribute ? $attr($this) : $attr;
+        $value = $attr instanceof \Closure || $attr instanceof DerivedAttributeInterface ? $attr($this) : $attr;
         
         return isset($value) ? $value : $default;
     }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -9,6 +9,7 @@ use Jasny\HttpMessage\Stream;
 use Jasny\HttpMessage\Uri;
 use Jasny\HttpMessage\UploadedFile;
 use Jasny\HttpMessage\DerivedAttribute;
+use Jasny\HttpMessage\DerivedAttributeInterface;
 use Jasny\HttpMessage\Headers as HeaderObject;
 
 /**
@@ -1118,8 +1119,6 @@ class ServerRequestTest extends PHPUnit_Framework_TestCase
 
     public function testWithAttributeAsCallback()
     {
-        $request = null;
-        
         $request = $this->baseRequest->withAttribute('foo', function ($arg) use (&$request) {
             $this->assertSame($request, $arg);
             return ['bar', 'zoo'];
@@ -1131,7 +1130,7 @@ class ServerRequestTest extends PHPUnit_Framework_TestCase
 
     public function testWithAttributeAsObject()
     {
-        $attribute = $this->getMockBuilder(DerivedAttribute::class)->getMock();
+        $attribute = $this->createMock(DerivedAttributeInterface::class);
         $request = $this->baseRequest->withAttribute('foo', $attribute);
         
         $attribute->expects($this->once())


### PR DESCRIPTION
Renamed DerivedAttribute to DerivedAttributeInterface